### PR TITLE
Repair some <Link /> errors.

### DIFF
--- a/src/components/Cart.js
+++ b/src/components/Cart.js
@@ -56,16 +56,18 @@ export default function Cart({ products }) {
                                 exit="exit"
                             >
                                 <Link href={`/details?productId=${product.id}`}>
-                                    <img
-                                        className="w-80 p-2 rounded"
-                                        src={product.image}
-                                        alt={product.name}
-                                        aria-label={product.name}
-                                        title={product.name}
-                                    />
-                                    <strong className="mb-3 transition-colors duration-300 text-gray-700 hover:text-gray-800">
-                                        {product.name}
-                                    </strong>
+                                    <>
+                                        <img
+                                            className="w-80 p-2 rounded"
+                                            src={product.image}
+                                            alt={product.name}
+                                            aria-label={product.name}
+                                            title={product.name}
+                                        />
+                                        <strong className="mb-3 transition-colors duration-300 text-gray-700 hover:text-gray-800">
+                                            {product.name}
+                                        </strong>
+                                    </>
                                 </Link>
 
                                 <button

--- a/src/components/Cart.js
+++ b/src/components/Cart.js
@@ -56,7 +56,7 @@ export default function Cart({ products }) {
                                 exit="exit"
                             >
                                 <Link href={`/details?productId=${product.id}`}>
-                                    <>
+                                    <div>
                                         <img
                                             className="w-80 p-2 rounded"
                                             src={product.image}
@@ -67,7 +67,7 @@ export default function Cart({ products }) {
                                         <strong className="mb-3 transition-colors duration-300 text-gray-700 hover:text-gray-800">
                                             {product.name}
                                         </strong>
-                                    </>
+                                    </div>
                                 </Link>
 
                                 <button

--- a/src/layout/LateralMenu.js
+++ b/src/layout/LateralMenu.js
@@ -38,7 +38,7 @@ export default function LateralMenu() {
                                 </Link>
                             </li>{' '}
                             <li className="mb-8 relative">
-                                <Link href="/cart" passHref>
+                                <Link href="/cart">
                                     <div>
                                         <FontAwesomeIcon
                                             icon={faShoppingBag}
@@ -52,7 +52,7 @@ export default function LateralMenu() {
                                 </div>
                             </li>
                             <li className="mt-8 relative">
-                                <Link href="/likes" passHref>
+                                <Link href="/likes">
                                     <div>
                                         <FontAwesomeIcon
                                             icon={faHeart}

--- a/src/layout/LateralMenu.js
+++ b/src/layout/LateralMenu.js
@@ -8,6 +8,10 @@ import {
     faHeart,
 } from '@fortawesome/free-solid-svg-icons';
 
+const MyFontawesomeIcon = React.forwardRef((props, _ref) => {
+    return <FontAwesomeIcon {...props} />;
+});
+
 export default function LateralMenu() {
     const productsAmount = useSelector(state => state.cart.products.length);
     const likesAmount = useSelector(state => state.user.likedProducts.length);
@@ -27,8 +31,8 @@ export default function LateralMenu() {
                     <nav>
                         <ul>
                             <li className="mb-8">
-                                <Link href="/">
-                                    <FontAwesomeIcon
+                                <Link href="/" passHref>
+                                    <MyFontawesomeIcon
                                         icon={faClipboardList}
                                         size="lg"
                                         className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"
@@ -36,8 +40,8 @@ export default function LateralMenu() {
                                 </Link>
                             </li>{' '}
                             <li className="mb-8 relative">
-                                <Link href="/cart">
-                                    <FontAwesomeIcon
+                                <Link href="/cart" passHref>
+                                    <MyFontawesomeIcon
                                         icon={faShoppingBag}
                                         size="lg"
                                         className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"
@@ -48,8 +52,8 @@ export default function LateralMenu() {
                                 </div>
                             </li>
                             <li className="mt-8 relative">
-                                <Link href="/likes">
-                                    <FontAwesomeIcon
+                                <Link href="/likes" passHref>
+                                    <MyFontawesomeIcon
                                         icon={faHeart}
                                         size="lg"
                                         className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"

--- a/src/layout/LateralMenu.js
+++ b/src/layout/LateralMenu.js
@@ -8,10 +8,6 @@ import {
     faHeart,
 } from '@fortawesome/free-solid-svg-icons';
 
-const MyFontawesomeIcon = React.forwardRef((props, _ref) => {
-    return <FontAwesomeIcon {...props} />;
-});
-
 export default function LateralMenu() {
     const productsAmount = useSelector(state => state.cart.products.length);
     const likesAmount = useSelector(state => state.user.likedProducts.length);
@@ -31,21 +27,25 @@ export default function LateralMenu() {
                     <nav>
                         <ul>
                             <li className="mb-8">
-                                <Link href="/" passHref>
-                                    <MyFontawesomeIcon
-                                        icon={faClipboardList}
-                                        size="lg"
-                                        className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"
-                                    />
+                                <Link href="/">
+                                    <div>
+                                        <FontAwesomeIcon
+                                            icon={faClipboardList}
+                                            size="lg"
+                                            className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"
+                                        />
+                                    </div>
                                 </Link>
                             </li>{' '}
                             <li className="mb-8 relative">
                                 <Link href="/cart" passHref>
-                                    <MyFontawesomeIcon
-                                        icon={faShoppingBag}
-                                        size="lg"
-                                        className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"
-                                    />
+                                    <div>
+                                        <FontAwesomeIcon
+                                            icon={faShoppingBag}
+                                            size="lg"
+                                            className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"
+                                        />
+                                    </div>
                                 </Link>
                                 <div className="bg-yellow-burn flex items-center text-white font-bold w-4 h-4 rounded-full p-1 absolute top-0 left-60p text-2xs">
                                     {productsAmount}
@@ -53,11 +53,13 @@ export default function LateralMenu() {
                             </li>
                             <li className="mt-8 relative">
                                 <Link href="/likes" passHref>
-                                    <MyFontawesomeIcon
-                                        icon={faHeart}
-                                        size="lg"
-                                        className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"
-                                    />
+                                    <div>
+                                        <FontAwesomeIcon
+                                            icon={faHeart}
+                                            size="lg"
+                                            className="text-gray-500 cursor-pointer transition-colors hover:text-gray-600 duration-500 ease-in-out"
+                                        />
+                                    </div>
                                 </Link>
                                 <div className="bg-yellow-burn flex items-center text-white font-bold w-4 h-4 rounded-full p-1 absolute top-0 left-60p text-2xs">
                                     {likesAmount}


### PR DESCRIPTION
In `layout/LateralMenu`: 

As of Next/Link 9 (I guess), if the child of Link is a function component, in addition to using passHref, we wrap the component in React.forwardRef. [Docs here](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-function-component)

I created a custom component which will use the React.forwardRef to pass props to the FontawesomeIcon function component.

In `components/Cart.js`:

Link appears to render only one child, so I wrap the the whole thing with a ` <> </>` fragment.

